### PR TITLE
Added support for more file types

### DIFF
--- a/ios/RNIcloudFilePicker.m
+++ b/ios/RNIcloudFilePicker.m
@@ -20,7 +20,7 @@ RCT_EXPORT_METHOD(showFilePicker:(RCTResponseSenderBlock) callback)
         self.alertWindow.windowLevel = UIWindowLevelAlert + 1;
         [self.alertWindow makeKeyAndVisible];
         
-        self.documentPickerController = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:@[(NSString*)kUTTypePDF, (NSString*)kUTTypeJPEG, (NSString*)kUTTypePNG, (NSString*)kUTTypeGIF] inMode:UIDocumentPickerModeImport];
+        self.documentPickerController = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:@[(NSString*)kUTTypePDF, (NSString*)kUTTypeJPEG, (NSString*)kUTTypePNG, (NSString*)kUTTypeGIF, (NSString*)kUTTypeImage, (NSString*)kUTTypeVideo, (NSString*)kUTTypeQuickTimeMovie, (NSString*)kUTTypeAudio, (NSString*)kUTTypeMP3] inMode:UIDocumentPickerModeImport];
         self.documentPickerController.delegate = self;
         [self.alertWindow.rootViewController presentViewController: self.documentPickerController animated: YES completion: nil];
     });

--- a/ios/RNIcloudFilePicker.m
+++ b/ios/RNIcloudFilePicker.m
@@ -20,7 +20,7 @@ RCT_EXPORT_METHOD(showFilePicker:(RCTResponseSenderBlock) callback)
         self.alertWindow.windowLevel = UIWindowLevelAlert + 1;
         [self.alertWindow makeKeyAndVisible];
         
-        self.documentPickerController = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:@[(NSString*)kUTTypePDF, (NSString*)kUTTypeJPEG, (NSString*)kUTTypePNG, (NSString*)kUTTypeGIF, (NSString*)kUTTypeImage, (NSString*)kUTTypeVideo, (NSString*)kUTTypeQuickTimeMovie, (NSString*)kUTTypeAudio, (NSString*)kUTTypeMP3] inMode:UIDocumentPickerModeImport];
+        self.documentPickerController = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:@[(NSString*)kUTTypePDF, (NSString*)kUTTypeJPEG, (NSString*)kUTTypePNG, (NSString*)kUTTypeGIF, (NSString*)kUTTypeImage, (NSString*)kUTTypeVideo, (NSString*)kUTTypeQuickTimeMovie, (NSString*)kUTTypeAudio, (NSString*)kUTTypeMP3, (NSString*)kUTTypeMPEG4] inMode:UIDocumentPickerModeImport];
         self.documentPickerController.delegate = self;
         [self.alertWindow.rootViewController presentViewController: self.documentPickerController animated: YES completion: nil];
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-icloud-file-picker",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "File Picker for iOS in React Native",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Problem
Users on iOS currently can't pick audio or video files in the file picker.

### Solution
Add support for audio and video files.