### PR TITLE
Adds a few more file types

### DIFF
--- a/ios/RNIcloudFilePicker.m
+++ b/ios/RNIcloudFilePicker.m
@@ -20,7 +20,7 @@ RCT_EXPORT_METHOD(showFilePicker:(RCTResponseSenderBlock) callback)
         self.alertWindow.windowLevel = UIWindowLevelAlert + 1;
         [self.alertWindow makeKeyAndVisible];
         
-        self.documentPickerController = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:@[(NSString*)kUTTypePDF, (NSString*)kUTTypeJPEG, (NSString*)kUTTypePNG, (NSString*)kUTTypeGIF, (NSString*)kUTTypeImage, (NSString*)kUTTypeVideo, (NSString*)kUTTypeQuickTimeMovie, (NSString*)kUTTypeAudio, (NSString*)kUTTypeMP3, (NSString*)kUTTypeMPEG4] inMode:UIDocumentPickerModeImport];
+        self.documentPickerController = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:@[(NSString*)kUTTypePDF, (NSString*)kUTTypeJPEG, (NSString*)kUTTypePNG, (NSString*)kUTTypeGIF, (NSString*)kUTTypeImage, (NSString*)kUTTypeVideo, (NSString*)kUTTypeQuickTimeMovie, (NSString*)kUTTypeAudio, (NSString*)kUTTypeMP3, (NSString*)kUTTypeMPEG4, (NSString*)@"org.openxmlformats.wordprocessingml.document", (NSString*)@"org.openxmlformats.spreadsheetml.sheet", (NSString*)@"org.openxmlformats.presentationml.presentation", (NSString*)kUTTypeText] inMode:UIDocumentPickerModeImport];
         self.documentPickerController.delegate = self;
         [self.alertWindow.rootViewController presentViewController: self.documentPickerController animated: YES completion: nil];
     });


### PR DESCRIPTION
### Problem
A maker wanted to upload `.docx` files to their Adalo app, which wasn't supported.

### Solution
Add support for `.docx` files.

### Notes
Turns out it's a little more complicated to add support for Microsoft files (surprise surprise), but I found something on stack overflow that worked...
I also added support for spreadsheets and presentations while I was at it. Didn't test it, but it didn't break anything so 🤷 
This does not support `.doc` files. Not sure why, but didn't want to spend the time to figure it out.

### Related PRs:
https://github.com/AdaloHQ/template-app/pull/15